### PR TITLE
Update sat-utils to accomodate changes to logging in some apps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "auth-checker"
-version = "2.1.1"
+version = "2.1.2"
 authors = [
   { name="Ryan Semmler", email="rsemmle@ncsu.edu" },
   { name="Luc Sanchez", email="lgsanche@ncsu.edu" },
@@ -32,7 +32,7 @@ dependencies = [
     "google-auth==2.19.1",
     "casbin_redis_adapter==1.2.0",
     "casbin_pymongo_adapter==1.1.0",
-    "sat-utils==1.7.0",
+    "sat-utils==1.7.4",
 ]
 
 [project.optional-dependencies]

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -78,7 +78,7 @@ requests-oauthlib==1.3.1
     # via sat-utils
 rsa==4.9
     # via google-auth
-sat-utils==1.5.0
+sat-utils==1.7.4
     # via auth-checker (pyproject.toml)
 simpleeval==0.9.13
     # via casbin

--- a/requirements/casbin_extra/casbin.txt
+++ b/requirements/casbin_extra/casbin.txt
@@ -83,7 +83,7 @@ requests-oauthlib==1.3.1
     # via sat-utils
 rsa==4.9
     # via google-auth
-sat-utils==1.5.0
+sat-utils==1.7.4
     # via auth-checker (pyproject.toml)
 simpleeval==0.9.13
     # via casbin

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -346,7 +346,7 @@ rsa==4.9
     # via google-auth
 ruff==0.1.1
     # via auth-checker (pyproject.toml)
-sat-utils==1.5.0
+sat-utils==1.7.4
     # via auth-checker (pyproject.toml)
 send2trash==1.8.3
     # via jupyter-server


### PR DESCRIPTION
Auth checker makes no use of the changes introduced in `sat-utils=1.7.4`, but the service apps that list Auth-Checker and Sat-utils as requirements do. This version bump is required to prevent version mismatches